### PR TITLE
Add support for a "close all discarded tabs" option

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -63,7 +63,7 @@ a {
 .group {
 	padding: 5px 0;
 }
-.optsCurrent, .optsAll, .optsSelected {
+.optsCurrent, .optsAll, .optsSelected, .optsCloseAll {
 	border-bottom: 1px solid #ccc;
 }
 

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -42,6 +42,12 @@
 		</div>
 	</div>
 
+	<div class="group optsCloseAll">
+		<div class="menuOption" id="closeAllDiscarded">
+			<i class="fa fa-trash"></i> <span class="optionText">Close all discarded tabs</span>
+		</div>
+	</div>
+
 	<div class="group optsSettings">
 		<div class="menuOption" id="settingsLink">
 			<i class="fa fa-wrench"></i> <span class="optionText">Settings</span>

--- a/src/js/eventPage.js
+++ b/src/js/eventPage.js
@@ -406,6 +406,28 @@ function discardAllTabsInAllWindows() {
   });
 }
 
+function closeAllDiscardedTabs() {
+  chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+    var curWindowId = tabs[0].windowId;
+    chrome.windows.get(curWindowId, {populate: true}, function(curWindow) {
+      curWindow.tabs.forEach(function (tab) {
+        if (isDiscarded(tab)) {
+          chrome.tabs.remove(tab.id);
+        }
+      });
+    });
+  });
+}
+
+function closeDiscardedTabsInAllWindows() {
+  chrome.tabs.query({}, function (tabs) {
+    tabs.forEach(function (currentTab) {
+      if (isDiscarded(tab))
+        chrome.tabs.remove(tab.id);
+    });
+  });
+}
+
 function reloadAllTabs() {
   chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
     var curWindowId = tabs[0].windowId;
@@ -625,6 +647,10 @@ function messageRequestListener(request, sender, sendResponse) {
     reloadSelectedTabs();
     break;
 
+  case 'closeAllDiscarded':
+      closeAllDiscardedTabs();
+      break;
+
   default:
     break;
   }
@@ -652,6 +678,10 @@ function commandListener (command) {
 
   } else if (command === '6-reload-all-windows') {
     reloadAllTabsInAllWindows();
+  } else if (command === '7-close-all-discarded-tabs') {
+       closeAllDiscardedTabs();
+  } else if (command === '8-close-all-discarded-windows') {
+       closeDiscardedTabsInAllWindows();
   }
 }
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -133,6 +133,10 @@
       });
       window.close();
     });
+    document.getElementById('closeAllDiscarded').addEventListener('click', function (e) {
+      chrome.runtime.sendMessage({ action: 'closeAllDiscarded' });
+      window.close();
+    });
 
     chrome.runtime.sendMessage({ action: 'requestCurrentTabInfo' }, function (info) {
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -48,6 +48,12 @@
     },
     "6-reload-all-windows": {
       "description": "Reload all tabs in all windows"
+    },
+    "7-close-all-discarded-tabs": {
+      "description": "Close all discarded tabs in active window"
+    },
+    "8-close-all-discarded-windows": {
+      "description": "Close all discarded tabs in all windows"
     }
   }
 }


### PR DESCRIPTION
This option allows the user to close all discarded tabs.

As a user, I often end up with many discarded tabs with a few
undiscarded tabs mixed in.  This option has saved me a bunch of
headache having to search for all of the active tabs when I want
to clean up the old unused tabs.