### PR TITLE
Skip pinned tabs when discarding all tabs

### DIFF
--- a/src/js/eventPage.js
+++ b/src/js/eventPage.js
@@ -389,7 +389,7 @@ function discardAllTabs() {
     var curWindowId = tabs[0].windowId;
     chrome.windows.get(curWindowId, {populate: true}, function(curWindow) {
       curWindow.tabs.forEach(function (tab) {
-        if (!tab.active) {
+        if (!tab.active && !tab.pinned) {
           requestTabSuspension(tab, true);
         }
       });


### PR DESCRIPTION
Pinned tabs are exempt from Chrome's normal discard process and should
probably be exempt from "discard all" as well.