### PR TITLE
Discard all tabs at startup

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -60,6 +60,10 @@
 			<input type="checkbox" id="batteryCheck" class='option' />
 			<label for="batteryCheck" class="cbLabel">Only auto-discard if running on battery</label>
 		</div>
+		<div class="formRow autoDiscardOption">
+			<input type="checkbox" id="discardAtStartup" class='option' />
+			<label for="discardAtStartup" class="cbLabel">Discard all tabs at startup</label>
+		</div>
 
 		<h2>Whitelist&nbsp;
 			<i class="fa fa-question-circle" title="

--- a/src/js/eventPage.js
+++ b/src/js/eventPage.js
@@ -50,13 +50,17 @@ chrome.runtime.onStartup.addListener(function () {
   ga('require', 'displayfeatures');
   ga('send', 'pageview', '/eventPage.html');
 
-  chrome.alarms.clearAll(function () {
-    localStorage.setItem(TEMPORARY_WHITELIST, []);
-    tabStates.clearTabStates(function () {
-      chrome.tabs.query({active: true, currentWindow: true}, function (tabs) {
-        if (tabs.length > 0) {
-          localStorage.setItem(CURRENT_TAB_ID, tabs[0].id);
-        }
+  storage.getOptions(function (options) {
+    chrome.alarms.clearAll(function () {
+      localStorage.setItem(TEMPORARY_WHITELIST, []);
+      tabStates.clearTabStates(function () {
+        chrome.tabs.query({active: true, currentWindow: true}, function (tabs) {
+          // Discarding all tabs after clearTabStates and after forcing Chrome to query all tab states seems to make sense.
+          if (options[storage.DISCARD_STARTUP]) { discardAllTabs(); }
+          if (tabs.length > 0) {
+            localStorage.setItem(CURRENT_TAB_ID, tabs[0].id);
+          }
+        });
       });
     });
   });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -27,7 +27,8 @@ function initialise(options) {
     'timeToDiscard': storage.SUSPEND_TIME,
     'whitelist': storage.WHITELIST,
     'addContextMenu': storage.ADD_CONTEXT,
-    "syncOptions": storage.SYNC_OPTIONS,
+    'syncOptions': storage.SYNC_OPTIONS,
+    'discardAtStartup': storage.DISCARD_STARTUP
   };
   elementIdMap = invert(elementPrefMap);
 

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -15,6 +15,7 @@
     NO_NAG: 'noNag',
     WHITELIST: 'whitelist',
     SYNC_OPTIONS: 'syncOptions',
+    DISCARD_STARTUP: 'discardAtStartup',
 
     getOption: getOption,
     getOptions: getOptions,
@@ -159,6 +160,7 @@
     defaults[self.NO_NAG] = false;
     defaults[self.WHITELIST] = '';
     defaults[self.SYNC_OPTIONS] = true;
+    defaults[self.DISCARD_STARTUP] = false;
 
     return defaults;
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "The Great Discarder",
+  "name": "RK Discarder",
   "description": "Automatically discards unused tabs to free up system resources",
-  "version": "0.1.3",
+  "version": "0.1.3.1",
   "permissions": [
     "tabs",
     "storage",
@@ -17,7 +17,7 @@
   "content_scripts": [
   ],
   "browser_action": {
-    "default_title": "The Great Discarder",
+    "default_title": "RK Discarder Discarder",
     "default_icon": "img/icon19.png",
     "default_popup": "html/popup.html"
   },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "RK Discarder",
+  "name": "The Great Discarder",
   "description": "Automatically discards unused tabs to free up system resources",
-  "version": "0.1.3.1",
+  "version": "0.1.3",
   "permissions": [
     "tabs",
     "storage",
@@ -17,7 +17,7 @@
   "content_scripts": [
   ],
   "browser_action": {
-    "default_title": "RK Discarder Discarder",
+    "default_title": "The Great Discarder",
     "default_icon": "img/icon19.png",
     "default_popup": "html/popup.html"
   },


### PR DESCRIPTION
Recent versions of Chrome use much more memory per tab, so this option saves A LOT of memory when starting with lots of tabs.
See Issue #2 